### PR TITLE
Add QueryPair object, improve __repr__

### DIFF
--- a/comparator/__init__.py
+++ b/comparator/__init__.py
@@ -5,8 +5,8 @@ from comparator.comps import (
     FIRST_COMP,
     DEFAULT_COMP)
 from comparator.config import DbConfig
-from comparator.models import Comparator, ComparatorSet
+from comparator.models import Comparator, ComparatorSet, QueryPair
 
 
-__all__ = [db, BASIC_COMP, LEN_COMP, FIRST_COMP, DEFAULT_COMP, DbConfig, Comparator, ComparatorSet]
+__all__ = [db, BASIC_COMP, LEN_COMP, FIRST_COMP, DEFAULT_COMP, DbConfig, Comparator, ComparatorSet, QueryPair]
 __version__ = '0.3.2'

--- a/comparator/config.py
+++ b/comparator/config.py
@@ -51,33 +51,27 @@ class DbConfig(object):
 
     def __init__(self, config_file=None):
         if config_file is not None:
-            _log.info('Setting config from provided path')
+            _log.debug('Setting config from provided path')
             self._set_config_from_file(config_file)
 
         if self._config is None:
             env_config_file = os.getenv('COMPARATOR_CONFIG_FILE', None)
             if env_config_file:
-                _log.info('Setting config from environment variable')
+                _log.debug('Setting config from environment variable')
                 env_config_file = Path(env_config_file).expanduser().resolve()
                 self._set_config_from_file(env_config_file)
             else:
-                _log.warning('Environment variable not set, falling back')
+                _log.debug('Environment variable not set, falling back')
                 self._set_config_from_file(DEFAULT_CONFIG_FILE)
 
         if self._config is None:
             raise AttributeError('Could not find valid configuration file')
         else:
-            _log.info('Found configuration file at %s', self._config.as_posix())
+            _log.debug('Found configuration file at %s', self._config.as_posix())
             self._load_dbs()
 
     def __repr__(self):
-        return '%s -- %r' % (self.__class__, self._config)
-
-    def __str__(self):
-        return '%s: %r' % (self.__class__.__name__,
-                           [db['name'] for db in self.dbs
-                            if isinstance(db, dict) and
-                            db.get('name')])
+        return '<DbConfig({self._config}): {self._dbs}>'.format(self=self)
 
     @property
     def dbs(self):
@@ -112,10 +106,10 @@ class DbConfig(object):
 
         for db in dbs:
             if not isinstance(db, dict):
-                _log.warning('Misconfigured db, ignoring : %r', db)
+                _log.debug('Misconfigured db, ignoring : %r', db)
                 continue
             if not db.get('name'):
-                _log.warning('Db has no name, ignoring : %r', db)
+                _log.debug('Db has no name, ignoring : %r', db)
                 continue
 
             cleaned_name = self._clean_db_name(db['name'])

--- a/comparator/config.py
+++ b/comparator/config.py
@@ -71,7 +71,10 @@ class DbConfig(object):
             self._load_dbs()
 
     def __repr__(self):
-        return '<DbConfig({self._config}): {self._dbs}>'.format(self=self)
+        return "<DbConfig('{self._config}'): {self._dbs}>".format(self=self)
+
+    def __str__(self):
+        return str(self._config)
 
     @property
     def dbs(self):

--- a/comparator/db/base.py
+++ b/comparator/db/base.py
@@ -1,8 +1,6 @@
 """
     Base class for establishing connections to source databases
 """
-from __future__ import unicode_literals
-
 import os
 
 from comparator.util import ABC, abstractmethod

--- a/comparator/db/base.py
+++ b/comparator/db/base.py
@@ -36,7 +36,7 @@ class BaseDb(ABC):
 
             Should set self._conn with the connection object
         """
-        pass
+        raise NotImplementedError()
 
     def connect(self):
         """Connect to the source database
@@ -53,7 +53,7 @@ class BaseDb(ABC):
         """
             Close any open connection
         """
-        pass
+        raise NotImplementedError()
 
     def close(self):
         """Close any open connection
@@ -79,7 +79,7 @@ class BaseDb(ABC):
             Returns:
                 QueryResult containing the query result
         """
-        pass
+        raise NotImplementedError()
 
     @abstractmethod
     def execute(self, query_string, **kwargs):
@@ -97,4 +97,4 @@ class BaseDb(ABC):
             Returns:
                 None
         """
-        pass
+        raise NotImplementedError()

--- a/comparator/db/bigquery.py
+++ b/comparator/db/bigquery.py
@@ -45,14 +45,11 @@ class BigQueryDb(BaseDb):
                 self._conn_kwargs[k] = v
 
     def __repr__(self):
-        return '%s -- %r' % (self.__class__, self._conn_kwargs['project'])
+        return '<BigQueryDb({project})>'.format(project=self._conn_kwargs['project'])
 
-    def __str__(self):
-        if self._name is not None:
-            return self._name
-        elif self.project is not None:
-            return self.project
-        return self.__class__.__name__
+    @property
+    def name(self):
+        return self._name
 
     @property
     def project(self):

--- a/comparator/db/postgres.py
+++ b/comparator/db/postgres.py
@@ -39,12 +39,11 @@ class PostgresDb(BaseDb):
             self._engine = sqlalchemy.create_engine(url, connect_args=conn_params)
 
     def __repr__(self):
-        return '%s -- %r' % (self.__class__, self._engine.url)
+        return '<{db.__class__.__name__}({db._engine.url.host})>'.format(db=self)
 
-    def __str__(self):
-        if self._name is not None:
-            return self._name
-        return self._engine.url.host
+    @property
+    def name(self):
+        return self._name
 
     def _connect(self):
         self._conn = self._engine.connect()

--- a/comparator/db/query.py
+++ b/comparator/db/query.py
@@ -1,8 +1,6 @@
 """
     Base classes to house the results of queries against a source databse
 """
-from __future__ import unicode_literals
-
 import copy
 import datetime
 import decimal

--- a/comparator/db/query.py
+++ b/comparator/db/query.py
@@ -108,10 +108,7 @@ class QueryResult(object):
         self._keys = keys
 
     def __repr__(self):
-        return '%r' % self._result
-
-    def __str__(self):
-        return str(self.__repr__())
+        return '<QueryResult: {qr._result}>'.format(qr=self)
 
     def __bool__(self):
         return bool(self._result)

--- a/comparator/db/query.py
+++ b/comparator/db/query.py
@@ -108,6 +108,9 @@ class QueryResult(object):
     def __repr__(self):
         return '<QueryResult: {qr._result}>'.format(qr=self)
 
+    def __str__(self):
+        return self.json()
+
     def __bool__(self):
         return bool(self._result)
 

--- a/comparator/exceptions.py
+++ b/comparator/exceptions.py
@@ -4,5 +4,9 @@
 from __future__ import unicode_literals
 
 
+class QueryFormatError(Exception):
+    pass
+
+
 class InvalidCompSetException(Exception):
     pass

--- a/comparator/exceptions.py
+++ b/comparator/exceptions.py
@@ -1,7 +1,6 @@
 """
     Exception classes specific to comparator
 """
-from __future__ import unicode_literals
 
 
 class QueryFormatError(Exception):

--- a/comparator/models.py
+++ b/comparator/models.py
@@ -37,7 +37,7 @@ class QueryPair(object):
         self._set_empty()
 
     def __repr__(self):
-        return '<QueryPair({qp._left} || {qp._right})>'.format(qp=self)
+        return '<QueryPair: {qp._left} || {qp._right}>'.format(qp=self)
 
     @property
     def lresult(self):
@@ -260,7 +260,7 @@ class Comparator(object):
 
     def __repr__(self):
         if self._name is None:
-            return '<{c.__class__}>'.format(c=self)
+            return '<Comparator()>'
         return '<Comparator({c._name})>'.format(c=self)
 
     @property
@@ -270,6 +270,18 @@ class Comparator(object):
     @property
     def results(self):
         return self._results
+
+    @property
+    def query_results(self):
+        return self._qp.query_results
+
+    @property
+    def lresult(self):
+        return self._qp._lresult
+
+    @property
+    def rresult(self):
+        return self._qp._rresult
 
     def _set_empty(self):
         """
@@ -365,9 +377,7 @@ class ComparatorSet(object):
         The resulting set of Comparator objects can be iterated upon and run/checked in a variety of ways.
 
         Args:
-            left : BaseDb - The "left" source database, against which the "left" query will run
-            right : BaseDb - The "right" source database, against which the "right" query will run
-            queries : list - The set of two-member tuples each containing the lquery and rquery strings
+            query_pairs : list - A list of instantiated QueryPair objects
 
         Kwargs:
             comps : list - The set of comparisons that correspond to each query pair. If None, the default_comp or
@@ -378,7 +388,7 @@ class ComparatorSet(object):
                            the list of queries.
             default_comp : callable - The default comparison to use if no comps are passed. Ignored if comps is passed.
     """
-    def __init__(self, query_pairs=None, comps=None, names=None, default_comp=None):
+    def __init__(self, query_pairs, comps=None, names=None, default_comp=None):
         self._set_query_pairs(query_pairs)
         self._set_comps(comps, default_comp)
         self._set_names(names)

--- a/comparator/models.py
+++ b/comparator/models.py
@@ -1,8 +1,6 @@
 """
     Base classes for running comparisons between two databases
 """
-from __future__ import unicode_literals
-
 import copy
 import inspect
 import logging

--- a/comparator/models.py
+++ b/comparator/models.py
@@ -112,7 +112,7 @@ class QueryPair(object):
             rquery = self._rquery
             keys = [key.strip('{ }') for key in formatting]
 
-            _log.info('Found result formatting for keys : %r', keys)
+            _log.info('While formatting rquery, found slot for keys : %r', keys)
 
             for fmt, key in zip(formatting, keys):
                 try:

--- a/tests/db/test_base.py
+++ b/tests/db/test_base.py
@@ -1,3 +1,4 @@
+import mock
 import pytest
 
 import comparator.db
@@ -16,24 +17,26 @@ def test_base_db():
     assert db._conn is None
     assert db.connected is False
 
-    db.connect()
+    with pytest.raises(NotImplementedError):
+        db.connect()
     assert db._conn is None
     assert db.connected is False
 
     db._conn = 'immaconnection'
-    db.connect()
+    with mock.patch('comparator.db.base.BaseDb._connect'):
+        db.connect()
     assert db.connected is True
 
-    db.close()
+    with mock.patch('comparator.db.base.BaseDb._close'):
+        db.close()
     assert db._conn is None
     assert db.connected is False
 
-    db.close()
+    with mock.patch('comparator.db.base.BaseDb._close'):
+        db.close()
 
     with pytest.raises(TypeError):
         db.query()
-    db.query('select * from nowhere')
 
     with pytest.raises(TypeError):
         db.execute()
-    db.execute("insert into nowhere select 'nothing'")

--- a/tests/db/test_base.py
+++ b/tests/db/test_base.py
@@ -32,6 +32,10 @@ def test_base_db():
     assert db._conn is None
     assert db.connected is False
 
+    with mock.patch('comparator.db.base.BaseDb._connect'):
+        db.connect()
+    assert db.connected is False
+
     with mock.patch('comparator.db.base.BaseDb._close'):
         db.close()
 
@@ -40,3 +44,12 @@ def test_base_db():
 
     with pytest.raises(TypeError):
         db.execute()
+
+    with pytest.raises(NotImplementedError):
+        db.query('select 1')
+
+    with pytest.raises(NotImplementedError):
+        db.execute('insert 1')
+
+    with pytest.raises(NotImplementedError):
+        db._close()

--- a/tests/db/test_bigquery.py
+++ b/tests/db/test_bigquery.py
@@ -71,25 +71,22 @@ def test_bigquery():
     assert bq1._db_type is None
     assert bq1.project is None
 
-    assert repr(bq1) == "<class 'comparator.db.bigquery.BigQueryDb'> -- None"
-    assert str(bq1) == 'BigQueryDb'
-
 
 def test_with_kwargs():
     name = 'Alphabet'
     bq1 = BigQueryDb(name)
-    assert str(bq1) == name
+    assert str(bq1) == '<BigQueryDb(None)>'
+    assert bq1.name == name
 
     bq2 = BigQueryDb(project=project)
-    assert repr(bq2) == "<class 'comparator.db.bigquery.BigQueryDb'> -- '{}'".format(project)
-    assert str(bq2) == project
+    assert str(bq2) == '<BigQueryDb({})>'.format(project)
     assert bq2.project == project
     assert bq2._conn_kwargs == expected_conn_kwargs
 
     bq3 = BigQueryDb()
-    assert str(bq3) == 'BigQueryDb'
+    assert str(bq3) == '<BigQueryDb(None)>'
     bq3.project = project
-    assert str(bq3) == project
+    assert str(bq3) == '<BigQueryDb({})>'.format(project)
 
     bq4 = BigQueryDb(genuflect='the-vatican-rag', locution='DE')
     assert bq4._conn_kwargs == BIGQUERY_DEFAULT_CONN_KWARGS

--- a/tests/db/test_postgres.py
+++ b/tests/db/test_postgres.py
@@ -20,19 +20,17 @@ def test_postgres():
     assert pg._name is None
     assert pg._db_type == 'postgresql'
 
-    assert repr(pg) == "<class 'comparator.db.postgres.PostgresDb'> -- {}".format(expected_default_url)
-    assert str(pg) == 'localhost'
-
 
 def test_with_kwargs():
     name = 'Euphegenia Doubtfire, dear.'
     pg1 = PostgresDb(name)
-    assert str(pg1) == name
+    assert str(pg1) == '<PostgresDb(localhost)>'
+    assert pg1.name == name
 
     conn_string = 'postgresql://user:pass@host:5432/db'
     pg2 = PostgresDb(conn_string=conn_string)
     pg2._conn_kwargs is None
-    assert str(pg2) == 'host'
+    assert str(pg2) == '<PostgresDb(host)>'
 
     host = 'notlocahost'
     pg3 = PostgresDb(host=host)

--- a/tests/db/test_query.py
+++ b/tests/db/test_query.py
@@ -4,6 +4,7 @@ import json
 import mock
 import pandas as pd
 import pytest
+import types
 
 from collections import OrderedDict
 from google.cloud.bigquery.table import RowIterator
@@ -34,7 +35,7 @@ def test_queryresult():
 
     itr = get_mock_iterator(RowIterator, list())
     qr = QueryResult(itr)
-    assert qr.keys() == list()
+    assert isinstance(qr.keys(), types.GeneratorType)
     assert bool(qr) is False
 
     itr = get_mock_iterator(ResultProxy, results)
@@ -58,16 +59,12 @@ def test_queryresult():
                      (7, decimal.Decimal('8'), datetime.datetime(2018, 10, 1, 0, 0))]
     expected_json = json.dumps(results, cls=DtDecEncoder)
     expected_df = pd.DataFrame(results)
-    expected_str = (
-        "[OrderedDict([('a', 1), ('b', Decimal('2')), ('c', datetime.date(2018, 8, 1))]), "
-        "OrderedDict([('a', 4), ('b', Decimal('5')), ('c', datetime.date(2018, 9, 1))]), "
-        "OrderedDict([('a', 7), ('b', Decimal('8')), ('c', datetime.datetime(2018, 10, 1, 0, 0))])]")
 
     assert qr.list() == expected_list
-    assert qr.values() == expected_list
+    assert [v for v in qr.values()] == expected_list
     assert qr.json() == expected_json
     assert qr.df().equals(expected_df)
-    assert str(qr) == expected_str
+    assert str(qr) == expected_json
 
     expected_items = {'a': (1, 4, 7),
                       'b': (decimal.Decimal(2.0), decimal.Decimal(5.0), decimal.Decimal(8.0)),

--- a/tests/db/test_query.py
+++ b/tests/db/test_query.py
@@ -17,6 +17,8 @@ results = [OrderedDict([('a', 1), ('b', decimal.Decimal(2.0)), ('c', datetime.da
            OrderedDict([('a', 7), ('b', decimal.Decimal(8.0)), ('c', datetime.datetime(2018, 10, 1))])]
 malformed_results = [OrderedDict([('a', 1), ('b', 2)]),
                      OrderedDict([('a', 3), ('c', 4)])]
+other_results = [OrderedDict([('a', 1), ('b', 2)]),
+                 OrderedDict([('a', 3), ('b', 4)])]
 
 
 def get_mock_iterator(spec, values):
@@ -77,6 +79,61 @@ def test_queryresult():
     assert qr.get(1) is None
     assert qr.get('d') is None
 
+    assert isinstance(qr.keys(), types.GeneratorType)
+    expected_keys = ['a', 'b', 'c']
+    for i, k in enumerate(qr.keys()):
+        assert k == expected_keys[i]
+
+
+def test_queryresult_manipulation():
+    itr = get_mock_iterator(ResultProxy, results)
+    qr = QueryResult(itr)
+    itr2 = get_mock_iterator(ResultProxy, other_results)
+    qr2 = QueryResult(itr2)
+
+    with pytest.raises(NotImplementedError):
+        qr.append(5)
+    qr.append(qr[0])
+    assert len(qr) == 4
+    assert qr[-1] == qr[0]
+    with pytest.raises(ValueError):
+        qr.append(qr2[0])
+
+    with pytest.raises(NotImplementedError):
+        qr.extend([5, 6, 7])
+    qr.extend(qr)
+    assert len(qr) == 8
+    assert qr[:4] == qr[4:]
+    with pytest.raises(ValueError):
+        qr.extend(qr2)
+
+    empty_qr = QueryResult()
+    empty_qr.append(qr[0])
+    assert empty_qr._keys == ['a', 'b', 'c']
+    assert len(empty_qr) == 1
+
+    empty_qr2 = QueryResult()
+    empty_qr2.extend(qr2)
+    assert empty_qr2._keys == ['a', 'b']
+    assert len(empty_qr2) == 2
+
+    filtered = qr.filter(lambda row: row.a < 7)
+    assert isinstance(filtered, QueryResult)
+    assert filtered is not qr
+    assert len(filtered) == 6
+
+    qr.filter(lambda row: row.a < 4, inplace=True)
+    assert len(qr) == 4
+
+    r = qr.pop()
+    assert isinstance(r, QueryResultRow)
+    assert len(qr) == 3
+
+    qr.append(filtered.filter(lambda row: row.a > 1)[0])
+    qr.extend(qr)
+    r = qr.pop(3)
+    assert r.a == 4
+
 
 def test_queryresultrow():
     itr = get_mock_iterator(ResultProxy, results)
@@ -127,6 +184,8 @@ def test_queryresultrcol():
     with pytest.raises(IndexError):
         qrc[3]
 
+    assert not qrc == 3
+    assert qrc != 3
     assert len(qrc) == 3
 
     assert qrc._key == 'a'
@@ -134,6 +193,12 @@ def test_queryresultrcol():
 
     assert str(QueryResultCol('a', ('one', 'two', 'three'))) == "('one', 'two', 'three')"
     assert str(QueryResultCol(u'a', (u'one', u'two', u'three'))) == "('one', 'two', 'three')"
+
+    expected_vals = (1, 4, 7)
+    for i, v in enumerate(qrc):
+        assert v == expected_vals[i]
+
+    assert qrc[0:1] == expected_vals[0:1]
 
 
 def test_dtdecencoder():

--- a/tests/db/test_redshift.py
+++ b/tests/db/test_redshift.py
@@ -22,9 +22,6 @@ def test_redshift():
     assert rs._conn_kwargs['port'] == 5439
     assert rs._db_type == expected_db_type
 
-    assert repr(rs) == "<class 'comparator.db.redshift.RedshiftDb'> -- {}".format(expected_default_url)
-    assert str(rs) == 'localhost'
-
     rs1 = RedshiftDb(port=1234)
     assert rs1._conn_kwargs['port'] == 1234
 
@@ -33,8 +30,8 @@ def test_postgres_and_redshift():
     rs = RedshiftDb(name='red')
     pg = PostgresDb(name='blue')
 
-    assert str(rs) == 'red'
-    assert str(pg) == 'blue'
+    assert str(rs) == '<RedshiftDb(localhost)>'
+    assert str(pg) == '<PostgresDb(localhost)>'
 
     assert rs._conn_kwargs
     assert rs._conn_kwargs['port'] == 5439

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -73,10 +73,7 @@ def test_default_config():
     assert conf._config == test_config_file
     assert conf.dbs == expected_db_list
 
-    assert repr(conf) == "<class 'comparator.config.DbConfig'> -- %r" % test_config_file
-    assert str(conf) == 'DbConfig: %r' % [db['name'] for db in expected_db_list
-                                          if isinstance(db, dict) and
-                                          db.get('name')]
+    assert str(conf) == str(test_config_file)
 
 
 def test_env_variable():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,6 +16,7 @@ other_query = 'select count(*) from somewhere'
 left_query_results = [{'a': 1, 'b': 2, 'c': 3}, {'a': 4, 'b': 5, 'c': 6}]
 right_query_results = [{'a': 1, 'b': 2, 'c': 3}, {'a': 4, 'b': 5, 'c': 6}]
 mismatch_right_query_results = [{'a': 1, 'b': 2, 'c': 3}, {'a': 4, 'b': 5, 'c': 6}, {'a': 7, 'b': 8, 'c': 9}]
+string_query_results = [{'a': 'one', 'b': 'two', 'c': 'three'}, {'a': 'four', 'b': 'five', 'c': 'six'}]
 
 
 def get_mock_query_result(values):
@@ -27,6 +28,7 @@ def get_mock_query_result(values):
 left_results = get_mock_query_result(left_query_results)
 right_results = get_mock_query_result(right_query_results)
 mismatch_right_results = get_mock_query_result(mismatch_right_query_results)
+string_results = get_mock_query_result(string_query_results)
 
 expected_default_result = ('basic_comp', True)
 expected_multiple_result = [
@@ -64,6 +66,10 @@ def test_query_pair_queries():
     qp._lresult = left_results
     formatted = qp._format_rquery()
     assert formatted == 'select * from somewhere where id in (1, 4)'
+
+    qp._lresult = string_results
+    formatted = qp._format_rquery()
+    assert formatted == "select * from somewhere where id in ('one', 'four')"
 
 
 def test_comparator():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,6 +17,7 @@ left_query_results = [{'a': 1, 'b': 2, 'c': 3}, {'a': 4, 'b': 5, 'c': 6}]
 right_query_results = [{'a': 1, 'b': 2, 'c': 3}, {'a': 4, 'b': 5, 'c': 6}]
 mismatch_right_query_results = [{'a': 1, 'b': 2, 'c': 3}, {'a': 4, 'b': 5, 'c': 6}, {'a': 7, 'b': 8, 'c': 9}]
 string_query_results = [{'a': 'one', 'b': 'two', 'c': 'three'}, {'a': 'four', 'b': 'five', 'c': 'six'}]
+unicode_query_results = [{u'a': u'one', u'b': u'two', u'c': u'three'}, {u'a': u'four', u'b': u'five', u'c': u'six'}]
 
 
 def get_mock_query_result(values):
@@ -29,6 +30,7 @@ left_results = get_mock_query_result(left_query_results)
 right_results = get_mock_query_result(right_query_results)
 mismatch_right_results = get_mock_query_result(mismatch_right_query_results)
 string_results = get_mock_query_result(string_query_results)
+unicode_results = get_mock_query_result(unicode_query_results)
 
 expected_default_result = ('basic_comp', True)
 expected_multiple_result = [
@@ -68,6 +70,10 @@ def test_query_pair_queries():
     assert formatted == 'select * from somewhere where id in (1, 4)'
 
     qp._lresult = string_results
+    formatted = qp._format_rquery()
+    assert formatted == "select * from somewhere where id in ('one', 'four')"
+
+    qp._lresult = unicode_results
     formatted = qp._format_rquery()
     assert formatted == "select * from somewhere where id in ('one', 'four')"
 
@@ -141,9 +147,9 @@ def test_compare_multiple():
             assert c.get_query_results() == (left_results, right_results)
 
     assert isinstance(c.lresult, QueryResult)
-    assert c.lresult.a == (1, 4)
+    assert str(c.lresult.a) == '(1, 4)'
     assert isinstance(c.rresult, QueryResult)
-    assert c.lresult.b == (2, 5)
+    assert str(c.lresult.b) == '(2, 5)'
 
     for i, result in enumerate(c.compare()):
         assert result == expected_multiple_result[i]


### PR DESCRIPTION
# Changelist
- `QueryPair` class created
  - Adds a layer of abstraction on the queries and databases that comparisons are run against
  - In particular, this allows for the "right" query to directly reference the output of the "left" query
- `ComparatorSet.from_list` method removed
  - The logic was inherently complex and repetitive, and the `from_dict` method gives identical functionality that is much more explicit
- All `__repr__` strings improved to better follow convention and be generally more readable
- `DbConfig` logging changed to `DEBUG` level
- `QueryResultCol` class created
  - Improves abstraction on column of data from the `QueryResult`
  - Avoids iterating over entire result to just pull one key from each row
  - Gracefully handles unicode formatting issues in python 2
- Adds tests to bring coverage back to 100%