### PR TITLE
Make right DB and rquery optional

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.4.0rc2 (2018-12-05)
+---------------------
+
+- BREAKING - ``QueryPair`` arguments order has changed (``QueryPair(left, lquery, right, rquery)``)
+- ``QueryPair``, ``Comparator``, and ``ComparatorSet`` no longer require a "right" Db
+
 0.4.0rc1 (2018-11-07)
 ---------------------
 

--- a/comparator/__init__.py
+++ b/comparator/__init__.py
@@ -9,4 +9,4 @@ from comparator.models import Comparator, ComparatorSet, QueryPair
 
 
 __all__ = [db, BASIC_COMP, LEN_COMP, FIRST_COMP, DEFAULT_COMP, DbConfig, Comparator, ComparatorSet, QueryPair]
-__version__ = '0.4.0rc1'
+__version__ = '0.4.0rc2'


### PR DESCRIPTION
There are times when a user may only want to run checks against a
single source database. In this case, requiring that a second database
be included is unnecessary and would require either duplication of work
or some sort of complicated workaround.

These changes make the `right` database (and subsequently `rquery`)
optional when instantiating a QueryPair, Comparator, and ComparatorSet.
The order of arguments has also changed for QueryPair, moving `right`
after `lquery` to allow for a `None` default. The class can now be
instantiated in this way: `QueryPair(left, lquery, right, rquery).