### PR TITLE
Add better transaction handling to Db objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.4.0rc3 (2018-12-05)
+---------------------
+
+- Adds better transaction handling in the PostgresDb class
+- Cleans up calls to connect() in the Db classes
+
 0.4.0rc2 (2018-12-05)
 ---------------------
 

--- a/comparator/__init__.py
+++ b/comparator/__init__.py
@@ -9,4 +9,4 @@ from comparator.models import Comparator, ComparatorSet, QueryPair
 
 
 __all__ = [db, BASIC_COMP, LEN_COMP, FIRST_COMP, DEFAULT_COMP, DbConfig, Comparator, ComparatorSet, QueryPair]
-__version__ = '0.4.0rc2'
+__version__ = '0.4.0rc3'

--- a/comparator/db/base.py
+++ b/comparator/db/base.py
@@ -42,7 +42,8 @@ class BaseDb(ABC):
         Returns:
             None
         """
-        self._connect()
+        if not self._connected:
+            self._connect()
         if self._conn:
             self._connected = True
 

--- a/comparator/db/bigquery.py
+++ b/comparator/db/bigquery.py
@@ -66,7 +66,6 @@ class BigQueryDb(BaseDb):
             else:
                 _log.warning('Path set by creds file does not exist: %s', self._bq_creds_file)
         self._conn = Client(**self._conn_kwargs)
-        self._connected = True
 
     def _close(self):
         """
@@ -76,8 +75,7 @@ class BigQueryDb(BaseDb):
         return
 
     def _query(self, query_string):
-        if not self._connected:
-            self.connect()
+        self.connect()
         query_job = self._conn.query(query_string)
         return query_job.result()
 
@@ -98,8 +96,7 @@ class BigQueryDb(BaseDb):
             Returns:
                 list of table names
         """
-        if not self._connected:
-            self.connect()
+        self.connect()
         dataset_ref = self._conn.dataset(dataset_id)
         return [t.table_id for t in self._conn.list_tables(dataset_ref)]
 
@@ -114,7 +111,6 @@ class BigQueryDb(BaseDb):
             Returns:
                 None
         """
-        if not self._connected:
-            self.connect()
+        self.connect()
         table_ref = self._conn.dataset(dataset_id).table(table_id)
         self._conn.delete_table(table_ref)

--- a/comparator/db/postgres.py
+++ b/comparator/db/postgres.py
@@ -52,13 +52,16 @@ class PostgresDb(BaseDb):
         self._conn.close()
 
     def _query(self, query_string, **kwargs):
-        if not self._connected:
-            self.connect()
         return self._conn.execute(query_string, **kwargs)
 
     def query(self, query_string, **kwargs):
+        self.connect()
         result = self._query(query_string, **kwargs)
+        self.close()
         return QueryResult(result)
 
     def execute(self, query_string, **kwargs):
-        self._query(query_string, **kwargs)
+        self.connect()
+        with self._conn.begin():
+            self._query(query_string, **kwargs)
+        self.close()

--- a/comparator/db/redshift.py
+++ b/comparator/db/redshift.py
@@ -16,8 +16,3 @@ class RedshiftDb(PostgresDb):
 
         super(RedshiftDb, self).__init__(
             *args, port=port, conn_params=conn_params, **kwargs)
-
-    def _query(self, query_string, **kwargs):
-        result = super(RedshiftDb, self)._query(query_string, **kwargs)
-        self.close()  # Close the connection each time since we're using SSL
-        return result

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -23,6 +23,15 @@ class mock_engine:
         result.keys.return_value = ['first', 'second', 'third']
         return result
 
+    def begin(self):
+        return self
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, *args):
+        pass
+
 
 @pytest.fixture(scope='module')
 def mock_create_engine():

--- a/tests/db/test_postgres.py
+++ b/tests/db/test_postgres.py
@@ -68,8 +68,8 @@ def test_query_without_connection(mock_create_engine):
         pg = PostgresDb()
 
     pg.query(query)
-    assert pg._conn
-    assert pg.connected is True
+    assert pg._conn is None
+    assert pg.connected is False
 
 
 def test_query_vs_execute(mock_create_engine):


### PR DESCRIPTION
Transactions on PostgresDb connections were never closed under the
previous configuration unless close() was called explicitly by the
end user. This could lead to long-running connections with negative
effects on DB performance or on things like read-replica lag.

These changes add an implicit close() to each call to the query() and
execute() methods, as well as a transaction block on execute(). There
is also some general cleanup on the way connect() is called throughout
the Db classes.