### PR TITLE
Gracefully handle QueryResultCol rquery format

### DIFF
--- a/comparator/db/query.py
+++ b/comparator/db/query.py
@@ -161,6 +161,33 @@ class QueryResultCol(object):
     def __ne__(self, other):
         return not self == other
 
+    def _rquery_format(self):
+        """
+            Special method for models.QueryPair to call when formatting the rquery
+
+            Returns:
+                str - The properly formatted values of this column
+        """
+        # Filter out None values
+        col = [v for v in self._col if v is not None]
+        _len = len(col)
+
+        # Calling str() on string type values to avoid unicode strings in python 2
+        if _len == 0:
+            # Gracefully handle an empty column
+            # Fill the result with a nonsense value to prevent false positives
+            return str("('__xxx__EMPTYRESULT__xxx__')")
+        elif _len == 1:
+            # Handle a single-value column without creating an invalid sql syntax.
+            # When formatting the rquery in a QueryPair, using the query with a
+            # value like (1,) will raise a syntax error.
+            v = col[0]
+            if isinstance(v, six.string_types):
+                v = "'{}'".format(str(v))
+            return str('({})'.format(v))
+        else:
+            return str(tuple([str(v) if isinstance(v, six.string_types) else v for v in col]))
+
 
 class QueryResult(object):
     def __init__(self, query_iterator=None):

--- a/comparator/models.py
+++ b/comparator/models.py
@@ -120,7 +120,7 @@ class QueryPair(object):
 
             for fmt, key in zip(formatting, keys):
                 try:
-                    repl = str(self._lresult[key])
+                    repl = self._lresult[key]._rquery_format()
                 except KeyError:
                     raise QueryFormatError('Key not found in lquery result : ' + key)
                 rquery = re.sub(fmt, repl, rquery)

--- a/tests/db/test_query.py
+++ b/tests/db/test_query.py
@@ -166,7 +166,7 @@ def test_queryresultrow():
     assert qrr.get('d') is None
 
 
-def test_queryresultrcol():
+def test_queryresultcol():
     itr = get_mock_iterator(ResultProxy, results)
     qr = QueryResult(itr)
     qrc = qr.a
@@ -199,6 +199,25 @@ def test_queryresultrcol():
         assert v == expected_vals[i]
 
     assert qrc[0:1] == expected_vals[0:1]
+
+
+def test_queryresultcol_rquery_format():
+    itr = get_mock_iterator(ResultProxy, results)
+    qr = QueryResult(itr)
+
+    assert qr['a']._rquery_format() == '(1, 4, 7)'
+
+    qrc2 = QueryResultCol('a', ('one', None, 'three'))
+    assert qrc2._rquery_format() == "('one', 'three')"
+
+    qrc3 = QueryResultCol('a', (None, ))
+    assert qrc3._rquery_format() == "('__xxx__EMPTYRESULT__xxx__')"
+
+    qrc4 = QueryResultCol('a', (1, None))
+    assert qrc4._rquery_format() == '(1)'
+
+    qrc5 = QueryResultCol('a', (None, 'one', None))
+    assert qrc5._rquery_format() == "('one')"
 
 
 def test_dtdecencoder():


### PR DESCRIPTION
Sometimes mixed or empty results could be returned by the lquery when
trying to format the rquery as a part of the QueryPair. These changes
separate the __str__ method of QueryResultCol from a new method that
can be used by the QuerPair to get a valid string to use to format
the rquery. The new _rquery_format method filters out None vaues and
properly returns a single-value result without a trailing tuple comma.